### PR TITLE
Fix mongodb connection uri

### DIFF
--- a/backend/config/db.ts
+++ b/backend/config/db.ts
@@ -7,10 +7,10 @@ const connectDB = async (): Promise<void> => {
 
   const connect = async (): Promise<void> => {
     try {
-      const mongoURI = process.env.MONGO_URI;
+      const mongoURI = process.env.MONGO_URI || process.env.MONGODB_URI;
 
       if (!mongoURI) {
-        throw new Error('MONGO_URI is not defined in environment variables');
+        throw new Error('MONGO_URI/MONGODB_URI is not defined in environment variables');
       }
 
       await mongoose.connect(mongoURI, {

--- a/seeder.ts
+++ b/seeder.ts
@@ -108,7 +108,8 @@ const SEED_VEHICLES: Omit<VehicleType, 'id'>[] = [
 
 const connectDB = async () => {
     try {
-        const conn = await mongoose.connect(process.env.MONGODB_URI as string);
+        const uri = process.env.MONGODB_URI || process.env.MONGO_URI;
+        const conn = await mongoose.connect(uri as string);
         console.log(`MongoDB Connected: ${conn.connection.host}`);
     } catch (error: any) {
         console.error(`Error: ${error.message}`);


### PR DESCRIPTION
Allow MongoDB connection string to be defined as MONGO_URI or MONGODB_URI to fix connection errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-7774b67e-8d57-404d-8c15-644185944858">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7774b67e-8d57-404d-8c15-644185944858">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Support both MONGO_URI and MONGODB_URI for MongoDB connections in the server and seeder. This fixes connection errors across environments and improves the error message when neither is set.

<!-- End of auto-generated description by cubic. -->

