### PR TITLE
Fix content security policy script errors

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -53,9 +53,7 @@ const scriptSrcDirectives = [
   "'self'",
   "https://cdn.tailwindcss.com",
   "'sha256-yMpSFLHnSZit6gvx0eHX89rw90Bv+QXITwFYyPzBrjc='",
-  "'sha256-NltRhJacRNw4BdgPSP+P8/KP9MS0BrJzNEpd27YU/YY='",
-  "'strict-dynamic'",
-
+  "'sha256-NltRhJacRNw4BdgPSP+P8/KP9MS0BrJzNEpd27YU/YY='"
 ];
 if (!isProduction) {
   scriptSrcDirectives.push('data:');


### PR DESCRIPTION
Remove `'strict-dynamic'` from CSP to allow scripts from self and CDN.

`'strict-dynamic'` was blocking scripts from `'self'` and `https://cdn.tailwindcss.com` because no nonces were being used on the script tags. Removing it re-enables host-based allowlisting for these sources.

---
<a href="https://cursor.com/background-agent?bcId=bc-9657ab85-d410-4754-853c-c44c67f0f493">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9657ab85-d410-4754-853c-c44c67f0f493">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix CSP script-src by removing 'strict-dynamic' so scripts from 'self' and https://cdn.tailwindcss.com load correctly. This resolves CSP console errors caused by missing nonces while keeping existing SHA-256 hashes.

<!-- End of auto-generated description by cubic. -->

