### PR TITLE
Run production server with missing file

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "commonjs",
-    "outDir": "/dist",
+    "outDir": "dist",
     "rootDir": "./",
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Change `outDir` in `tsconfig.json` to a relative path to correctly place build artifacts.

Previously, `outDir: "/dist"` caused TypeScript to compile files to an absolute `/dist` directory outside the project, leading to `dist/server.js` not being found when the server attempted to start.

---
<a href="https://cursor.com/background-agent?bcId=bc-5349759d-9143-4eb0-92ac-e8e39a3a45c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5349759d-9143-4eb0-92ac-e8e39a3a45c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

