### PR TITLE
Fix recommendation engine type errors

### DIFF
--- a/backend/ml/recommendationEngine.ts
+++ b/backend/ml/recommendationEngine.ts
@@ -79,15 +79,15 @@ class RecommendationEngine {
       vehicles.forEach((vehicle) => {
         this.vehicleFeatures.set(vehicle.id, {
           id: vehicle.id,
-          make: vehicle.make,
+          make: vehicle.make ?? "",
           model: vehicle.model,
-          year: vehicle.year,
-          price: vehicle.price,
-          km: vehicle.km,
+          year: vehicle.year ?? 0,
+          price: vehicle.price ?? 0,
+          km: vehicle.km ?? 0,
           fuel: vehicle.fuel,
           gearbox: vehicle.gearbox,
           color: vehicle.color,
-          doors: vehicle.doors,
+          doors: vehicle.doors ?? 0,
           views: vehicle.views || 0,
           likes: 0, // TODO: Implement likes count
           shares: 0, // TODO: Implement shares count


### PR DESCRIPTION
Coalesce optional `Vehicle` fields to default values to resolve TypeScript build errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-d072fcec-bfc3-4be8-9603-6acad32253f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d072fcec-bfc3-4be8-9603-6acad32253f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Defaulted optional Vehicle fields in the recommendation engine to stop TypeScript build errors and safely handle missing data. Set make to "", and year, price, km, and doors to 0 during feature extraction.

<!-- End of auto-generated description by cubic. -->

