### PR TITLE
Update notification, logging, and downtime alerts

### DIFF
--- a/backend/routes/analyticsRoutes.ts
+++ b/backend/routes/analyticsRoutes.ts
@@ -14,8 +14,10 @@ const router = express.Router();
 // Public endpoints for performance monitoring and offline sync (no auth required)
 router.post("/web-vitals", (req, res) => {
   try {
-    // Log web vitals data for performance monitoring
-    console.log("Web Vitals:", req.body);
+    // Optionally log in development when explicitly enabled
+    if (process.env.NODE_ENV !== "production" && process.env.LOG_WEB_VITALS === "true") {
+      console.debug("Web Vitals:", req.body);
+    }
     res.status(200).json({ success: true, message: "Web vitals recorded" });
   } catch (error) {
     console.error("Error recording web vitals:", error);
@@ -25,9 +27,11 @@ router.post("/web-vitals", (req, res) => {
 
 router.post("/batch", (req, res) => {
   try {
-    // Process batch analytics data from offline sync
-    const analyticsData = req.body;
-    console.log("Batch Analytics:", analyticsData);
+    // Process batch analytics data from offline sync (no verbose logging in prod)
+    if (process.env.NODE_ENV !== "production" && process.env.LOG_WEB_VITALS === "true") {
+      const analyticsData = req.body;
+      console.debug("Batch Analytics:", analyticsData);
+    }
     res.status(200).json({ success: true, message: "Batch analytics processed" });
   } catch (error) {
     console.error("Error processing batch analytics:", error);

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -5,7 +5,7 @@ import { FiMenu, FiX } from "react-icons/fi";
 import { useAuth } from "../hooks/useAuth.tsx";
 import DarkModeToggle from "./DarkModeToggle";
 import { prefetchRoute } from "../utils/prefetch.ts";
-import toast from "react-hot-toast";
+ 
 
 const baseNavLinks = [
   { name: "Início", path: "/" },
@@ -21,7 +21,7 @@ const Header: React.FC = () => {
   const { isAuthenticated } = useAuth();
   const [isScrolled, setIsScrolled] = useState(false);
   const location = useLocation();
-  const [pushSupported, setPushSupported] = useState(false);
+  
 
   const navLinks = isAuthenticated
     ? [...baseNavLinks, { name: "Admin", path: "/admin" }]
@@ -33,9 +33,7 @@ const Header: React.FC = () => {
     return () => window.removeEventListener("scroll", handleScroll);
   }, []);
 
-  useEffect(() => {
-    setPushSupported("serviceWorker" in navigator && "PushManager" in window);
-  }, []);
+  
 
   const isHome = location.pathname === "/";
   const isTransparent = isHome && !isScrolled;
@@ -53,43 +51,7 @@ const Header: React.FC = () => {
     return () => document.removeEventListener("click", onClick, true);
   }, [isOpen]);
 
-  const urlBase64ToUint8Array = (base64String: string) => {
-    const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
-    const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
-    const rawData = window.atob(base64);
-    const outputArray = new Uint8Array(rawData.length);
-    for (let i = 0; i < rawData.length; ++i) {
-      outputArray[i] = rawData.charCodeAt(i);
-    }
-    return outputArray;
-  };
-
-  const subscribeToPush = async () => {
-    try {
-      if (!("serviceWorker" in navigator)) {
-        toast.error("Push não suportado");
-        return;
-      }
-      const permission = await Notification.requestPermission();
-      if (permission !== "granted") {
-        toast.error("Permita as notificações no navegador");
-        return;
-      }
-      const reg = await navigator.serviceWorker.ready;
-      const vapidRes = await fetch("/api/push/vapid-public-key");
-      const { publicKey } = await vapidRes.json();
-      const convertedKey = urlBase64ToUint8Array(publicKey);
-      const sub = await reg.pushManager.subscribe({ userVisibleOnly: true, applicationServerKey: convertedKey });
-      await fetch("/api/push/subscribe", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(sub),
-      });
-      toast.success("Notificações ativadas!");
-    } catch (e) {
-      toast.error("Não foi possível ativar notificações");
-    }
-  };
+  
 
   const getNavLinkClass = ({ isActive }: { isActive: boolean }) =>
     `relative block py-2 px-3 transition-colors duration-300 font-medium group
@@ -144,15 +106,7 @@ const Header: React.FC = () => {
                 </span>
               </NavLink>
             ))}
-            {pushSupported && (
-              <button
-                onClick={subscribeToPush}
-                className="ml-2 bg-main-red text-white px-3 py-2 rounded-lg text-sm hover:bg-red-700"
-                title="Receber novos veículos"
-              >
-                Ativar Notificações
-              </button>
-            )}
+            
             <DarkModeToggle />
           </div>
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "docker:stop": "docker-compose down",
     "performance:audit": "npm run test:performance && npm run test:e2e",
     "ci": "npm run lint && npm run type-check && npm run test && npm run test:e2e",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "monitor:uptime": "ts-node scripts/uptime-monitor.ts"
   },
   "dependencies": {
     "@apollo/client": "^3.13.9",

--- a/scripts/uptime-monitor.ts
+++ b/scripts/uptime-monitor.ts
@@ -1,0 +1,97 @@
+import fs from "fs/promises";
+import path from "path";
+import nodemailer from "nodemailer";
+
+const MONITOR_URL = process.env.MONITOR_URL || "http://localhost:5000/health";
+const TIMEOUT_MS = Number(process.env.MONITOR_TIMEOUT_MS || 5000);
+const STATE_FILE = process.env.MONITOR_STATE_FILE || "/tmp/uptime-monitor-state.json";
+const ADMIN_EMAIL = process.env.ADMIN_EMAIL || "";
+
+async function fetchWithTimeout(url: string, timeoutMs: number): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    // @ts-ignore Node18 global fetch
+    const res: Response = await fetch(url, { signal: controller.signal } as any);
+    return res;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function readState(): Promise<"up" | "down" | null> {
+  try {
+    const data = await fs.readFile(STATE_FILE, "utf-8");
+    const parsed = JSON.parse(data);
+    if (parsed && (parsed.status === "up" || parsed.status === "down")) return parsed.status;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function writeState(status: "up" | "down") {
+  try {
+    await fs.mkdir(path.dirname(STATE_FILE), { recursive: true });
+  } catch {}
+  await fs.writeFile(STATE_FILE, JSON.stringify({ status, ts: Date.now() }));
+}
+
+function buildTransport() {
+  const host = process.env.SMTP_HOST || "smtp.gmail.com";
+  const port = Number(process.env.SMTP_PORT || 465);
+  const secure = (process.env.SMTP_SECURE || "true") === "true";
+  const user = process.env.EMAIL_USERNAME || "";
+  const pass = process.env.EMAIL_PASSWORD || "";
+  if (!user || !pass) {
+    throw new Error("EMAIL_USERNAME and EMAIL_PASSWORD must be set for uptime monitor");
+  }
+  return nodemailer.createTransport({ host, port, secure, auth: { user, pass } });
+}
+
+async function sendEmail(subject: string, html: string) {
+  if (!ADMIN_EMAIL) {
+    throw new Error("ADMIN_EMAIL is required to send uptime notifications");
+  }
+  const transporter = buildTransport();
+  const from = process.env.EMAIL_FROM || process.env.EMAIL_USERNAME || ADMIN_EMAIL;
+  await transporter.sendMail({ from, to: ADMIN_EMAIL, subject, html });
+}
+
+async function main() {
+  const prev = await readState();
+  let isUp = false;
+  try {
+    const res = await fetchWithTimeout(MONITOR_URL, TIMEOUT_MS);
+    isUp = res.ok;
+  } catch {
+    isUp = false;
+  }
+
+  const curr: "up" | "down" = isUp ? "up" : "down";
+
+  if (prev !== curr) {
+    // State changed -> notify
+    if (curr === "down") {
+      await sendEmail(
+        "[ALERTA] Site indisponível",
+        `<p>O monitor detectou indisponibilidade do site em <strong>${MONITOR_URL}</strong>.</p>
+         <p>Horário: ${new Date().toLocaleString()}</p>`
+      );
+    } else {
+      await sendEmail(
+        "[RECUPERAÇÃO] Site voltou ao ar",
+        `<p>O site voltou a responder em <strong>${MONITOR_URL}</strong>.</p>
+         <p>Horário: ${new Date().toLocaleString()}</p>`
+      );
+    }
+  }
+
+  await writeState(curr);
+}
+
+main().catch((err) => {
+  console.error("Uptime monitor error:", err);
+  process.exit(1);
+});
+


### PR DESCRIPTION
Refactor notification prompt to a toast on entry, reduce Web Vitals logging, and add an uptime email monitor.

---
<a href="https://cursor.com/background-agent?bcId=bc-01175968-fffb-4345-a0c1-f441b3fdc0c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-01175968-fffb-4345-a0c1-f441b3fdc0c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switches notification opt-in to a one-time toast on entry and centralizes push subscription in App. Reduces Web Vitals/analytics logging to dev-only when enabled, and adds an email-based uptime monitor.

- **New Features**
  - Entry toast to prompt web push opt-in (one-time via localStorage). Handles permission, VAPID key fetch, subscription, and success/error toasts.
  - Removes the Header notification button and related code.
  - Adds scripts/uptime-monitor.ts with email alerts on up/down state changes; adds npm run monitor:uptime.

- **Migration**
  - Configure env: ADMIN_EMAIL, EMAIL_USERNAME, EMAIL_PASSWORD. Optional: SMTP_HOST, SMTP_PORT, SMTP_SECURE, MONITOR_URL, MONITOR_TIMEOUT_MS, MONITOR_STATE_FILE.
  - Schedule npm run monitor:uptime to run periodically (e.g., every 1–5 minutes).
  - For local Web Vitals/analytics logs, set LOG_WEB_VITALS=true (non-production only).

<!-- End of auto-generated description by cubic. -->

