### PR TITLE
Handle redis connection and file virus errors

### DIFF
--- a/components/PerformanceDashboard.tsx
+++ b/components/PerformanceDashboard.tsx
@@ -15,7 +15,13 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from "recharts";
-import { AlertTriangle, CheckCircle, TrendingUp, TrendingDown, Activity, Clock, Database } from "lucide-react";
+import AlertTriangle from "lucide-react/dist/esm/icons/alert-triangle.js";
+import CheckCircle from "lucide-react/dist/esm/icons/check-circle.js";
+import TrendingUp from "lucide-react/dist/esm/icons/trending-up.js";
+import TrendingDown from "lucide-react/dist/esm/icons/trending-down.js";
+import Activity from "lucide-react/dist/esm/icons/activity.js";
+import Clock from "lucide-react/dist/esm/icons/clock.js";
+import Database from "lucide-react/dist/esm/icons/database.js";
 
 interface PerformanceMetrics {
   timestamp: number;

--- a/pages/AdminLoginPage.tsx
+++ b/pages/AdminLoginPage.tsx
@@ -2,7 +2,10 @@ import React, { useState, useMemo } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { useAuth } from "../hooks/useAuth.tsx";
 import { motion, useMotionValue, useTransform } from "framer-motion";
-import { Lock, User, ArrowLeft, Loader2 } from "lucide-react";
+import Lock from "lucide-react/dist/esm/icons/lock.js";
+import User from "lucide-react/dist/esm/icons/user.js";
+import ArrowLeft from "lucide-react/dist/esm/icons/arrow-left.js";
+import Loader2 from "lucide-react/dist/esm/icons/loader-2.js";
 import logo from "../assets/logo.png";
 
 const phrases = [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -102,6 +102,7 @@ export default defineConfig(({ mode }) => {
         target: "esnext",
         treeShaking: true,
       },
+      exclude: ["lucide-react"],
     },
     server: {
       port: 3000,


### PR DESCRIPTION
Disable Redis queue initialization in development and update `lucide-react` imports to resolve build errors.

The `lucide-react` changes (direct per-icon imports and Vite `optimizeDeps.exclude`) address a build error where `node_modules/lucide-react/dist/esm/icons/chrome.js` was being flagged by antivirus software, preventing the build from completing.

---
<a href="https://cursor.com/background-agent?bcId=bc-3197d129-a407-43b7-bafe-da12d86f8887">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3197d129-a407-43b7-bafe-da12d86f8887">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Prevents local crashes when Redis isn’t configured and fixes builds blocked by antivirus scanning lucide-react files. Queues auto-disable in non-production without Redis, and icon imports/Vite config avoid the flagged files.

- **Bug Fixes**
  - QueueManager: auto-disables queues when Redis isn’t configured in non-production or when DISABLE_QUEUES=true; skips Bull init; safe Redis shutdown; status reports “disabled”.
  - lucide-react: switch to per-icon ESM imports and exclude lucide-react from Vite optimizeDeps to avoid antivirus false positives.

- **Migration**
  - To use queues locally, set REDIS_URL/REDIS_HOST or REDIS_CLUSTER_NODES. To force-disable, set DISABLE_QUEUES=true.

<!-- End of auto-generated description by cubic. -->

