### PR TITLE
Fix vite ws proxy and float chat button

### DIFF
--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -161,7 +161,7 @@ const ChatWidget: React.FC = () => {
 					setOpen((v) => !v);
 					setUnread(0);
 				}}
-				className="fixed bottom-[6rem] right-6 z-40 rounded-full bg-main-red text-white shadow-lg w-14 h-14 flex items-center justify-center hover:bg-red-700 focus:outline-none relative"
+				className="fixed bottom-6 right-6 z-50 rounded-full bg-main-red text-white shadow-lg w-14 h-14 flex items-center justify-center hover:bg-red-700 focus:outline-none relative"
 				aria-label="Abrir chat"
 			>
 				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-7 h-7">
@@ -174,7 +174,7 @@ const ChatWidget: React.FC = () => {
 
 			{/* Chat panel */}
 			{open && (
-				<div className="fixed bottom-24 right-6 z-40 w-80 max-w-[90vw] bg-white dark:bg-gray-800 rounded-xl shadow-2xl border border-gray-200 dark:border-gray-700 overflow-hidden flex flex-col">
+				<div className="fixed bottom-24 right-6 z-50 w-80 max-w-[90vw] bg-white dark:bg-gray-800 rounded-xl shadow-2xl border border-gray-200 dark:border-gray-700 overflow-hidden flex flex-col">
 					<div className="px-4 py-3 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
 						<div className="text-sm font-semibold">Atendimento</div>
 						<button onClick={() => setOpen(false)} className="text-gray-500 hover:text-gray-800 dark:text-gray-300 dark:hover:text-white">

--- a/components/FloatingSocialButtons.tsx
+++ b/components/FloatingSocialButtons.tsx
@@ -46,7 +46,7 @@ const FloatingSocialButtons: React.FC<FloatingSocialButtonsProps> = ({ page }) =
   ];
 
   return (
-    <div className="fixed bottom-6 right-6 z-40 flex flex-col gap-3 items-end">
+    <div className="fixed bottom-6 right-20 z-40 flex flex-col gap-3 items-end">
       {showRealtime && page ? <RealTimeViewers page={page as string} variant="inline" /> : null}
 
       {buttons.map((btn) => (


### PR DESCRIPTION
Make the chat button a floating action button and adjust other floating elements to prevent overlap.

---
<a href="https://cursor.com/background-agent?bcId=bc-9183b7e4-cce0-4e96-b218-04bf93edde54">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9183b7e4-cce0-4e96-b218-04bf93edde54">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Converted the chat button into a floating action button and adjusted layering/positioning to prevent overlap with social buttons. Improves visibility and clickability on all pages.

- **Bug Fixes**
  - Raised chat button and panel to z-50.
  - Anchored chat button at bottom-6.
  - Moved floating social buttons to right-20 to avoid overlap.

<!-- End of auto-generated description by cubic. -->

