### PR TITLE
Fix unbounded cache for persisted queries

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -122,6 +122,7 @@ const startApollo = async () => {
     typeDefs,
     resolvers,
     plugins: isProduction ? [] : [ApolloServerPluginLandingPageLocalDefault()],
+    persistedQueries: false,
     context: ({ req, res }) => ({ req, res }),
   });
   await apolloServer.start();


### PR DESCRIPTION
Disable Apollo Automatic Persisted Queries to prevent denial of service via memory exhaustion from an unbounded cache.

---
<a href="https://cursor.com/background-agent?bcId=bc-940a2af2-7e78-42d5-b0e3-6db374353490">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-940a2af2-7e78-42d5-b0e3-6db374353490">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

